### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -5,6 +5,8 @@
 # For more information, see:
 # https://github.com/github/super-linter
 name: Lint Code Base
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/wazeerc/vison/security/code-scanning/1](https://github.com/wazeerc/vison/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level (root level) to explicitly define the permissions for the `GITHUB_TOKEN`. Since this is a linting workflow, it only needs read access to the repository contents. We will set `contents: read` as the permission, which is the least privilege required for this type of workflow.

The changes will be made at the root level of the workflow file, just below the `name` field, to apply the permissions to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
