### PR TITLE
Revert tree view long value wrapping fix

### DIFF
--- a/src/components/JsonTreeView.tsx
+++ b/src/components/JsonTreeView.tsx
@@ -281,7 +281,7 @@ const TreeNode: React.FC<TreeNodeProps> = ({
       return <span className="text-gray-500 italic">null</span>;
     }
     if (typeof value === 'string') {
-      return <span className="text-purple-800 text-wrap">"{value}"</span>; // Removed break-all
+      return <span className="text-purple-800">"{value}"</span>; // Removed break-all
     }
     if (typeof value === 'number') {
       return <span className="text-blue-600">{value}</span>;


### PR DESCRIPTION
Restore previous behavior by reverting the change that wrapped long string values in the tree view.