### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/db-purge.yml
+++ b/.github/workflows/db-purge.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 0 * * *'  # This means every day at midnight UTC
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   delete-rows:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/wazeerc/vison/security/code-scanning/2](https://github.com/wazeerc/vison/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only needs to execute a `curl` command to call an external API, it does not require any write permissions. The minimal required permission is `contents: read`, which allows the workflow to access the repository's contents if needed. This adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow permissions for the "Delete Rows Daily" automation to improve security. No changes to functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->